### PR TITLE
Changed data type of balance from int64 to float64

### DIFF
--- a/types.go
+++ b/types.go
@@ -126,8 +126,8 @@ type Collateral struct {
 // Balance is the balance of account.
 type Balance struct {
 	CurrencyCode string `json:"currency_code"` // currency_code
-	Amount       int64  `json:"amount"`        // amount
-	Available    int64  `json:"available"`     // available
+	Amount       float64  `json:"amount"`        // amount
+	Available    float64  `json:"available"`     // available
 }
 
 // ChildOrder is own child orders.


### PR DESCRIPTION
The bitflyer api returns float amounts which makes unmarshal return the following error

json: cannot unmarshal number 99999.0 into Go struct field Balance.amount of type int64